### PR TITLE
CENG-138: Use rignet branded cyphre logo

### DIFF
--- a/hawk/app/views/layouts/authentication.html.haml
+++ b/hawk/app/views/layouts/authentication.html.haml
@@ -31,7 +31,7 @@
           = _("Please ensure Javascript is enabled")
 
       %p.logo
-        = image_tag "logo/c_brand_logo.png", alt: _("Cyphre")
+        = image_tag "head/cyphre_rn_white_crop.png", alt: _("Cyphre")
 
       %h2
         = link_to _("High Availability Web Konsole"), login_path


### PR DESCRIPTION

<img width="438" alt="screen shot 2018-01-11 at 2 54 06 pm" src="https://user-images.githubusercontent.com/3772909/34846915-517710e4-f6df-11e7-8f96-1f838fa681d4.png">
Signed-off-by: Michael Crowther <crow404@gmail.com>