### PR TITLE
CENG-140: swap green hawk menu headers for cyphre yellow

### DIFF
--- a/hawk/app/assets/stylesheets/_theme.scss
+++ b/hawk/app/assets/stylesheets/_theme.scss
@@ -19,7 +19,7 @@ $sidebar-highlight-fg: rgb(247, 193, 82);
 $sidebar-link-fg: #fff;
 $sidebar-link-hover-fg: darken($sidebar-link-fg, 20.0%);
 $sidebar-separator-fg: #333;
-$sidebar-heading-fg: #00b268;
+$sidebar-heading-fg: rgb(244, 198, 81);
 $sidebar-fg: #fff;
 $sidebar-bg: #383c3e;
 


### PR DESCRIPTION
![screen shot 2018-01-14 at 12 00 00 pm](https://user-images.githubusercontent.com/3772909/34919015-a97be64e-f922-11e7-96fd-6f433d388a3b.png)
